### PR TITLE
Use microtesla instead of gauss

### DIFF
--- a/drone_racing_msgs/msg/SensorMag.msg
+++ b/drone_racing_msgs/msg/SensorMag.msg
@@ -2,6 +2,6 @@
 
 uint64 timestamp  # [μs] time since system start
 
-float32 x         # [gauss] magnetic field in the ENU board frame X-axis
-float32 y         # [gauss] magnetic field in the ENU board frame Y-axis
-float32 z         # [gauss] magnetic field in the ENU board frame Z-axis
+float32 x         # [μTesla] magnetic field in the ENU board frame X-axis
+float32 y         # [μTesla] magnetic field in the ENU board frame Y-axis
+float32 z         # [μTesla] magnetic field in the ENU board frame Z-axis


### PR DESCRIPTION
Microtesla is used in BF, besides Tesla is in the International System of Units perhaps better use it instead of Gauss